### PR TITLE
Move custom IDP insert logic into the identity pre-insert handler.

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -142,6 +142,59 @@ bedrock.events.on('bedrock-session-http.session.get', function(req, session) {
 
 bedrock.events.on('bedrock-views.vars.get', addViewVars);
 
+bedrock.events.on('bedrock-identity.insert', function(options, callback) {
+  // add IDP identity defaults
+  var identity = options.identity;
+  var postInsert = options.postInsert;
+  // All IDP Identites must have a sysSlug specified, if not,
+  // skip idp specific additions.
+  if(!identity.sysSlug) {
+    // Store that we skipped this in postInsert, so we know not
+    // to emit a "created" event later
+    postInsert['bedrock-idp'] = {
+      failed: true
+    };
+    return callback();
+  }
+
+  var defaults = bedrock.util.clone(config.idp.defaults);
+  var clonedIdentity = bedrock.util.extend(
+    {}, defaults.identity, bedrock.util.clone(identity));
+  // Must mutate original identity object, so assign all props back over
+  for(var key in clonedIdentity) {
+    identity[key] = clonedIdentity[key];
+  }
+  // create identity ID from slug if not present
+  if(!('id' in identity)) {
+    identity.id = api.createIdentityId(identity.sysSlug);
+  }
+
+  // if using a 'did:', add resource role for local id
+  if(identity.id.indexOf('did:') === 0) {
+    identity.sysResourceRole = identity.sysResourceRole || [];
+    identity.sysResourceRole.push({
+      sysRole: 'identity.registered',
+      resource: [api.createIdentityId(identity.sysSlug)]
+    });
+  }
+  callback();
+});
+
+
+bedrock.events.on('bedrock-identity.postInsert', function(options, callback) {
+  var postInsert = options.postInsert;
+  if(postInsert['bedrock-idp'] && postInsert['bedrock-idp'].failed) {
+    return callback();
+  }
+  var details = {identity: options.identity};
+  bedrock.events.emitLater({
+    type: 'bedrock.Identity.created',
+    details: details
+  });
+  callback();
+});
+
+
 function addViewVars(req, vars, callback) {
   // add idp vars
   vars.idp = {};
@@ -182,6 +235,7 @@ api.createIdentityId = function(name) {
 };
 
 /**
+ * DEPRECATED
  * Creates a new Identity. The Identity must contain `id`.
  *
  * @param actor the Identity performing the action.
@@ -189,70 +243,7 @@ api.createIdentityId = function(name) {
  * @param callback(err, record) called once the operation completes.
  */
 api.createIdentity = function(actor, identity, callback) {
-  async.auto({
-    checkDuplicate: function(callback) {
-      // check for a duplicate to prevent generating password hashes
-      database.collections.identity.findOne(
-        {'identity.sysSlug': identity.sysSlug}, {'identity.sysSlug': true},
-        function(err, record) {
-          if(err) {
-            return callback(err);
-          }
-          if(record) {
-            // simulate duplicate identity error
-            err = new Error('Duplicate Identity.');
-            err.name = 'MongoError';
-            err.code = 11000;
-            return callback(err);
-          }
-          callback();
-        });
-    },
-    setDefaults: ['checkDuplicate', function(callback) {
-      var defaults = bedrock.util.clone(config.idp.defaults);
-      // add identity defaults
-      identity = bedrock.util.extend(
-        {}, defaults.identity, bedrock.util.clone(identity));
-      // create identity ID from slug if not present
-      if(!('id' in identity)) {
-        identity.id = api.createIdentityId(identity.sysSlug);
-      }
-
-      // if using a 'did:', add resource role for local id
-      if(identity.id.indexOf('did:') === 0) {
-        identity.sysResourceRole = identity.sysResourceRole || [];
-        identity.sysResourceRole.push({
-          sysRole: 'identity.registered',
-          resource: [api.createIdentityId(identity.sysSlug)]
-        });
-      }
-      callback();
-    }],
-    insert: ['setDefaults', function(callback, results) {
-      // insert the identity
-      var now = Date.now();
-      var record = {
-        id: database.hash(identity.id),
-        meta: {
-          created: now,
-          updated: now
-        },
-        identity: identity
-      };
-      brIdentity.insert(null, identity, function(err, record) {
-        if(err) {
-          return callback(err);
-        }
-        // return unhashed passcode in record
-        // FIXME: is this necessary.  If so, a new solution will need to be
-        // implemented since passcode generation is happening elsewhere.
-        // record.identity.sysPasscode = results.generatePasscode;
-        callback(null, record);
-      });
-    }]
-  }, function(err, results) {
-    callback(err, results.insert);
-  });
+  brIdentity.insert(actor, identity, callback);
 };
 
 /**

--- a/lib/services.identity.js
+++ b/lib/services.identity.js
@@ -516,11 +516,6 @@ api._createIdentity = function(options, req, callback) {
     }
     // result details
     var details = {identity: results.createIdentity};
-    // schedule identity created event
-    bedrock.events.emitLater({
-      type: 'bedrock.Identity.created',
-      details: details
-    });
     callback(null, details);
   });
 };


### PR DESCRIPTION
This uses the pre-insert event to handle IDP field additions whenever we insert an identity, which allows us to insert all of our identities through the brIdentity interface instead of having to special-case IDP identity creation with its own API.